### PR TITLE
Bump elixir dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Extreme.System.Mixfile do
   def project do
     [app: :extreme_system,
      version: "0.2.15",
-     elixir: "~> 1.5.0 or ~> 1.6.0 or ~> 1.7.0",
+     elixir: "~> 1.5.0 or ~> 1.6.0 or ~> 1.7.0 or ~> 1.8.0",
      source_url: "https://github.com/exponentially/extreme_system",
      description: """
      Building blocks for distributed systems


### PR DESCRIPTION
I'm running it fine with Elixir 1.8.0 - so this should be ok?
Otherwise I get warnings:

`warning: the dependency :extreme_system requires Elixir "~> 1.5.0 or ~> 1.6.0 or ~> 1.7.0" but you are running on v1.8.0`